### PR TITLE
Rework to follow ctx->lock for PM runtime get/put

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/spi/rtio.h>
 #include <zephyr/cache.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
 #include <soc.h>
@@ -86,6 +87,9 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 
 	if (NRF_SPIM_IS_320MHZ_SPIM(reg) && !(dev_data->ctx.config->operation & SPI_HOLD_ON_CS)) {
 		nrfy_spim_disable(reg);
+	}
+	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		pm_device_runtime_put(dev);
 	}
 }
 
@@ -457,6 +461,9 @@ static int transceive(const struct device *dev,
 	void *reg = dev_config->spim.p_reg;
 	int error;
 
+	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		pm_device_runtime_get(dev);
+	}
 	spi_context_lock(&dev_data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	error = configure(dev, spi_cfg);
@@ -568,21 +575,20 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 	.release = spi_nrfx_release,
 };
 
-#ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
-	int ret = 0;
+	int ret = -ENOTSUP;
 	struct spi_nrfx_data *dev_data = dev->data;
 	const struct spi_nrfx_config *dev_config = dev->config;
 
 	switch (action) {
+	case PM_DEVICE_ACTION_TURN_ON:
+		ret = 0;
+		break;
 	case PM_DEVICE_ACTION_RESUME:
 		ret = pinctrl_apply_state(dev_config->pcfg,
 					  PINCTRL_STATE_DEFAULT);
-		if (ret < 0) {
-			return ret;
-		}
 		/* nrfx_spim_init() will be called at configuration before
 		 * the next transfer.
 		 */
@@ -596,19 +602,14 @@ static int spim_nrfx_pm_action(const struct device *dev,
 
 		ret = pinctrl_apply_state(dev_config->pcfg,
 					  PINCTRL_STATE_SLEEP);
-		if (ret < 0) {
-			return ret;
-		}
 		break;
 
 	default:
-		ret = -ENOTSUP;
+		break;
 	}
 
 	return ret;
 }
-#endif /* CONFIG_PM_DEVICE */
-
 
 static int spi_nrfx_init(const struct device *dev)
 {
@@ -643,10 +644,12 @@ static int spi_nrfx_init(const struct device *dev)
 	spi_context_unlock_unconditionally(&dev_data->ctx);
 
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
-	return anomaly_58_workaround_init(dev);
-#else
-	return 0;
+	err = anomaly_58_workaround_init(dev);
+	if (err < 0) {
+		return err;
+	}
 #endif
+	return pm_device_driver_init(dev, spim_nrfx_pm_action);
 }
 /*
  * We use NODELABEL here because the nrfx API requires us to call

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -50,9 +50,11 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -60,6 +60,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -59,6 +59,7 @@
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -54,9 +54,11 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -57,3 +57,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+
+  drivers.spi.pm_runtime:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    filter: CONFIG_SOC_FAMILY_NORDIC_NRF

--- a/tests/drivers/spi/spi_loopback/boards/nrf51dk_nrf51822.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf51dk_nrf51822.overlay
@@ -7,6 +7,7 @@
 &spi1 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf52840dk_nrf52840.overlay
@@ -8,6 +8,7 @@
 	overrun-character = <0x00>;
 	rx-delay = <1>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf52dk_nrf52832.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf52dk_nrf52832.overlay
@@ -7,6 +7,7 @@
 &spi1 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -30,6 +30,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	memory-regions = <&cpuapp_dma_region>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -34,6 +34,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -29,6 +29,7 @@
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf9160dk_nrf9160.overlay
@@ -7,6 +7,7 @@
 &spi3 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -210,3 +210,8 @@ tests:
     platform_allow:
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1
+  drivers.spi.nrf_pm_runtime:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    filter: CONFIG_SOC_FAMILY_NORDIC_NRF


### PR DESCRIPTION
I've merged my changes on top of your branch. This exact changes were not tested, not even compiled.

My original changes work with older nRF Connect 2.6.1. I have tested tat set on nRF5340DK + x-nucleo-nfc-09 and customized code based on this: https://github.com/vouch-opensource/zephyr-nfc08a1.git

Now I do not see warnings about unbalanced suspend and communication with hardware looks normal.

I am not aware about Zephyr code style, hopefully there are not too many style errors here.